### PR TITLE
Escape password when it starts with dash

### DIFF
--- a/grass-desktop_main.py
+++ b/grass-desktop_main.py
@@ -140,10 +140,7 @@ def main():
 
         # Type the password and press Return (with a x ms delay between keystrokes)
         if password:
-            # Escape all special characters in the password, but avoid double escaping 
-            escaped_password = re.sub(r'(?<!\\)([\\^$*+?.()|[\]{}-])', r'\\\1'
-            subprocess.run(["xdotool", "type", "--delay", "125", escaped_password], check=True)
-            # subprocess.run(["xdotool", "type", "--delay", "125", re.sub("^-", "\-", password)], check=True)
+            subprocess.run(["xdotool", "type", "--delay", "125", re.sub("^-", "\-", password)], check=True)
         time.sleep(MAX_RETRY_MULTIPLIER)  # Wait added to help slow devices
 
         logging.info("Sending credentials...")

--- a/grass-desktop_main.py
+++ b/grass-desktop_main.py
@@ -5,6 +5,7 @@ import time
 import random
 import logging
 import subprocess
+import re
 
 
 def setup_logging():
@@ -139,7 +140,7 @@ def main():
 
         # Type the password and press Return (with a x ms delay between keystrokes)
         if password:
-            subprocess.run(["xdotool", "type", "--delay", "125", password], check=True)
+            subprocess.run(["xdotool", "type", "--delay", "125", re.sub("^-", "\-", password)], check=True)
         time.sleep(MAX_RETRY_MULTIPLIER)  # Wait added to help slow devices
 
         logging.info("Sending credentials...")

--- a/grass-desktop_main.py
+++ b/grass-desktop_main.py
@@ -140,7 +140,10 @@ def main():
 
         # Type the password and press Return (with a x ms delay between keystrokes)
         if password:
-            subprocess.run(["xdotool", "type", "--delay", "125", re.sub("^-", "\-", password)], check=True)
+            # Escape all special characters in the password, but avoid double escaping 
+            escaped_password = re.sub(r'(?<!\\)([\\^$*+?.()|[\]{}-])', r'\\\1'
+            subprocess.run(["xdotool", "type", "--delay", "125", escaped_password], check=True)
+            # subprocess.run(["xdotool", "type", "--delay", "125", re.sub("^-", "\-", password)], check=True)
         time.sleep(MAX_RETRY_MULTIPLIER)  # Wait added to help slow devices
 
         logging.info("Sending credentials...")


### PR DESCRIPTION
Hello! First of all, thanks for putting this in a docker image!

I tried to use it but turns out my password starts with a dash (`-`) so xdotool fails 😅 So, in this PR I'm escaping it using a simple regular expression. I tried it locally and it works fine and I'm able to login now

Maybe this needs to be backported to other python scripts but right now I'm only using the desktop version and I haven't check the other files...